### PR TITLE
Fix SSR

### DIFF
--- a/hocs/page.js
+++ b/hocs/page.js
@@ -45,12 +45,13 @@ export default function page(WrappedComponent) {
       const headers = ctx.req ? ctx.req.headers : {};
       const query = ctx.query;
       const clientAndStore = getClientAndStore({}, headers);
-      const props = { initialState: clientAndStore.reduxStore.getState(), headers, query };
+      let subProps;
       if (WrappedComponent.getInitialProps) {
         const extendedCtx = Object.assign({}, ctx, clientAndStore);
-        const subProps = await WrappedComponent.getInitialProps(extendedCtx);
-        Object.assign(props, subProps);
+        subProps = await WrappedComponent.getInitialProps(extendedCtx);
       }
+      const props = { initialState: clientAndStore.reduxStore.getState(), headers, query };
+      Object.assign(props, subProps);
       return props;
     }
 


### PR DESCRIPTION
I think there's a small error which is preventing proper SSR for the Apollo queries. By taking a snapshot of the redux state _before_ the WrappedComponent.getInitialProps has been called, the initialState is actually empty. Nothing is returned by the Apollo HOC so subProps is empty as well, and therefore the ApolloProvider ends up calling the query again on the client.

This PR fixes it, so the props.initialState passed through in the render includes the properly hydrated redux store.

Thanks for a great project BTW, it is very useful inspiration!